### PR TITLE
Issue #199 overlapping responsive issue

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1396,3 +1396,39 @@ label {
   padding: 0px 10px 0px 10px;
   text-decoration: none;
 }
+
+media (max-width: 1200px) {
+	.teach-top {
+		min-height: 480px;
+	}
+		.teach-bottom {
+		min-height: 255px;
+	}
+}
+
+@media (max-width: 990px) {
+	.teach-top {
+		min-height: 575px;
+	}
+		.teach-bottom {
+		min-height: 300px;
+	}
+}
+
+@media (max-width: 786px) {
+	.teach-top {
+		min-height: 585px;
+	}
+		.teach-bottom {
+		min-height: 355px;
+	}
+}
+
+@media (max-width: 768px) {
+	.teach-top {
+		min-height: 330px;
+	}
+	.teach-bottom {
+		min-height: 170px;
+	}
+}


### PR DESCRIPTION
I added media queries for the bootstrap breakpoints.

To see the fix: 
- check out this branch
- go to http://localhost:4000/teach.html
- resize the page and confirm that the buttons aren't overlapping the text

![image](https://cloud.githubusercontent.com/assets/4762269/6766774/7f438224-cfea-11e4-807d-4ee297aefd0d.png)
